### PR TITLE
.NET Core compatilibity

### DIFF
--- a/GeoTimeZone.sln
+++ b/GeoTimeZone.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeoTimeZone.Tests", "GeoTimeZone.Tests\GeoTimeZone.Tests.csproj", "{CA246E9E-379D-4D5D-BAD4-DA3557219C0F}"
 EndProject
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "GeoTimeZone.CORE", "GeoTimeZone\GeoTimeZone.CORE.xproj", "{4E9DF3AB-C2B4-40D1-9334-D346018725AB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +34,10 @@ Global
 		{D1EC7045-B2DD-42FF-A824-48455A16B000}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1EC7045-B2DD-42FF-A824-48455A16B000}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1EC7045-B2DD-42FF-A824-48455A16B000}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E9DF3AB-C2B4-40D1-9334-D346018725AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E9DF3AB-C2B4-40D1-9334-D346018725AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E9DF3AB-C2B4-40D1-9334-D346018725AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E9DF3AB-C2B4-40D1-9334-D346018725AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GeoTimeZone/GeoTimeZone.CORE.xproj
+++ b/GeoTimeZone/GeoTimeZone.CORE.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4e9df3ab-c2b4-40d1-9334-d346018725ab</ProjectGuid>
+    <RootNamespace>ClassLibrary1</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/GeoTimeZone/GeoTimeZone.csproj
+++ b/GeoTimeZone/GeoTimeZone.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/GeoTimeZone/GeoTimeZone.nuspec
+++ b/GeoTimeZone/GeoTimeZone.nuspec
@@ -1,15 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
     <id>GeoTimeZone</id>
-    <version>$version$</version>
+    <version>1.3.1</version>
     <title>Geo Time Zone</title>
-    <authors>$author$</authors>
-    <description>$description$</description>
+    <authors>foo</authors>
+    <description>bar</description>
     <language>en-US</language>
     <licenseUrl>https://raw.githubusercontent.com/mj1856/GeoTimeZone/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/mj1856/GeoTimeZone</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>timezone time zone geolocation geo latitude longitude coordinates iana tzdb</tags>
+    <dependencies>
+      <group targetFramework="netstandard1.0">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Threading" version="4.0.11" />
+      </group>
+      <group targetFramework=".NETPortable4.5-Profile259" />
+      <group targetFramework=".NETPortable4.0-Profile136" />
+    </dependencies>
   </metadata>
 </package>

--- a/GeoTimeZone/GeoTimeZone.nuspec
+++ b/GeoTimeZone/GeoTimeZone.nuspec
@@ -2,10 +2,10 @@
 <package>
   <metadata>
     <id>GeoTimeZone</id>
-    <version>1.3.1</version>
+    <version>$version$</version>
     <title>Geo Time Zone</title>
-    <authors>foo</authors>
-    <description>bar</description>
+    <authors>$author$</authors>
+    <description>$description$</description>
     <language>en-US</language>
     <licenseUrl>https://raw.githubusercontent.com/mj1856/GeoTimeZone/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/mj1856/GeoTimeZone</projectUrl>
@@ -24,7 +24,9 @@
         <dependency id="System.Threading" version="4.0.11" />
       </group>
       <group targetFramework=".NETPortable4.5-Profile259" />
+      <group targetFramework="portable45-net45+win8+wp8+wpa81" />
       <group targetFramework=".NETPortable4.0-Profile136" />
+      <group targetFramework="portable40-net40+sl5+win8+wp8" />
     </dependencies>
   </metadata>
 </package>

--- a/GeoTimeZone/GeoTimeZone.project.json
+++ b/GeoTimeZone/GeoTimeZone.project.json
@@ -1,0 +1,11 @@
+{
+	"runtimes":
+	{
+		"win": {}
+	},
+	"frameworks":
+	{
+		"net45": {},
+        	".NETPortable,Version=v4.0,Profile=Profile136": {}
+	}
+}

--- a/GeoTimeZone/TimeZoneLookup.cs
+++ b/GeoTimeZone/TimeZoneLookup.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace GeoTimeZone
 {
@@ -122,7 +123,11 @@ namespace GeoTimeZone
 
         private static IList<string> LoadLookupData()
         {
+#if NET40
             var assembly = typeof(TimezoneFileReader).Assembly;
+#else
+            var assembly = typeof(TimezoneFileReader).GetTypeInfo().Assembly;
+#endif
             using (var stream = assembly.GetManifestResourceStream("GeoTimeZone.TZL.dat"))
             {
                 if (stream == null)

--- a/GeoTimeZone/TimezoneFileReader.cs
+++ b/GeoTimeZone/TimezoneFileReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Reflection;
 
 namespace GeoTimeZone
 {
@@ -17,7 +18,11 @@ namespace GeoTimeZone
         {
             var ms = new MemoryStream();
 
+#if NET40
             var assembly = typeof(TimezoneFileReader).Assembly;
+#else
+            var assembly = typeof(TimezoneFileReader).GetTypeInfo().Assembly;
+#endif
             using (var stream = assembly.GetManifestResourceStream("GeoTimeZone.TZ.dat"))
             {
                 if (stream == null)

--- a/GeoTimeZone/project.json
+++ b/GeoTimeZone/project.json
@@ -4,7 +4,7 @@
     "authors": [ "The GeoTimeZone Authors" ],
     "description": "Provides an IANA time zone identifier from latitude and longitude coordinates.",
     "language": "en-US",
-    "copyright": "Copyright © Matt Johnson & Simon Bartlett",
+    "copyright": "Copyright Â© Matt Johnson & Simon Bartlett",
 
     "dependencies": {
     },
@@ -15,24 +15,24 @@
                 "define": [ "NET40" ]
             },
             "frameworkAssemblies": {
-                "mscorlib": "",
-                "System": "",
-                "System.Core": ""
+                "mscorlib": { "type": "build" },
+                "System": { "type": "build" },
+                "System.Core": { "type": "build" }
             }
         },
         ".NETPortable,Version=v4.5,Profile=Profile259": {
             "frameworkAssemblies": {
-                "System": "",
-                "System.Collections": "",
-                "System.Core": "",
-                "System.IO": "",
-                "System.Linq": "",
-                "System.Reflection": "",
-                "System.Resources.ResourceManager": "",
-                "System.Runtime": "",
-                "System.Runtime.Extensions": "",
-                "System.Text.Encoding": "",
-                "System.Threading": ""
+                "System": { "type": "build" },
+                "System.Collections": { "type": "build" },
+                "System.Core": { "type": "build" },
+                "System.IO": { "type": "build" },
+                "System.Linq": { "type": "build" },
+                "System.Reflection": { "type": "build" },
+                "System.Resources.ResourceManager": { "type": "build" },
+                "System.Runtime": { "type": "build" },
+                "System.Runtime.Extensions": { "type": "build" },
+                "System.Text.Encoding": { "type": "build" },
+                "System.Threading": { "type": "build" }
             }
         },
         "netstandard1.0": {
@@ -42,7 +42,10 @@
                 "System.IO": "4.1.0",
                 "System.Linq": "4.1.0",
                 "System.Reflection": "4.1.0",
-                "System.Resources.ResourceManager": "4.0.1",
+                "System.Resources.ResourceManager": {
+                    "version": "4.0.1",
+                    "type": "build"
+                },
                 "System.Runtime": "4.1.0",
                 "System.Runtime.Extensions": "4.1.0",
                 "System.Text.Encoding": "4.0.11",

--- a/GeoTimeZone/project.json
+++ b/GeoTimeZone/project.json
@@ -1,5 +1,10 @@
 {
     "version": "1.3.0-*",
+    "title": "Geo Time Zone",
+    "authors": [ "The GeoTimeZone Authors" ],
+    "description": "Provides an IANA time zone identifier from latitude and longitude coordinates.",
+    "language": "en-US",
+    "copyright": "Copyright © Matt Johnson & Simon Bartlett",
 
     "dependencies": {
     },
@@ -15,6 +20,21 @@
                 "System.Core": ""
             }
         },
+        ".NETPortable,Version=v4.5,Profile=Profile259": {
+            "frameworkAssemblies": {
+                "System": "",
+                "System.Collections": "",
+                "System.Core": "",
+                "System.IO": "",
+                "System.Linq": "",
+                "System.Reflection": "",
+                "System.Resources.ResourceManager": "",
+                "System.Runtime": "",
+                "System.Runtime.Extensions": "",
+                "System.Text.Encoding": "",
+                "System.Threading": ""
+            }
+        },
         "netstandard1.0": {
             "dependencies": {
                 "System.Collections": "4.0.11",
@@ -22,11 +42,11 @@
                 "System.IO": "4.1.0",
                 "System.Linq": "4.1.0",
                 "System.Reflection": "4.1.0",
+                "System.Resources.ResourceManager": "4.0.1",
                 "System.Runtime": "4.1.0",
                 "System.Runtime.Extensions": "4.1.0",
                 "System.Text.Encoding": "4.0.11",
                 "System.Threading": "4.0.11"
-
             }
         }
     },
@@ -37,9 +57,9 @@
         }
     },
     "packOptions": {
-        "summary": "Geo Time Zone",
         "owners": [ "The GeoTimeZone Authors" ],
         "tags": [ "timezone", "time", "zone", "geolocation", "geo", "latitude", "longitude", "coordinates", "iana", "tzdb" ],
+        "projectUrl": "https://github.com/mj1856/GeoTimeZone",
         "licenseUrl": "https://raw.githubusercontent.com/mj1856/GeoTimeZone/master/LICENSE",
         "repository": {
             "type": "git",

--- a/GeoTimeZone/project.json
+++ b/GeoTimeZone/project.json
@@ -1,0 +1,50 @@
+{
+    "version": "1.3.0-*",
+
+    "dependencies": {
+    },
+
+    "frameworks": {
+        ".NETPortable,Version=v4.0,Profile=Profile136": {
+            "buildOptions": {
+                "define": [ "NET40" ]
+            },
+            "frameworkAssemblies": {
+                "mscorlib": "",
+                "System": "",
+                "System.Core": ""
+            }
+        },
+        "netstandard1.0": {
+            "dependencies": {
+                "System.Collections": "4.0.11",
+                "System.Diagnostics.Debug": "4.0.11",
+                "System.IO": "4.1.0",
+                "System.Linq": "4.1.0",
+                "System.Reflection": "4.1.0",
+                "System.Runtime": "4.1.0",
+                "System.Runtime.Extensions": "4.1.0",
+                "System.Text.Encoding": "4.0.11",
+                "System.Threading": "4.0.11"
+
+            }
+        }
+    },
+    "buildOptions": {
+        "compile": [ "../SharedAssemblyInfo.cs" ],
+        "embed": {
+            "includeFiles": [ "TZ.dat", "TZL.dat" ]
+        }
+    },
+    "packOptions": {
+        "summary": "Geo Time Zone",
+        "owners": [ "The GeoTimeZone Authors" ],
+        "tags": [ "timezone", "time", "zone", "geolocation", "geo", "latitude", "longitude", "coordinates", "iana", "tzdb" ],
+        "licenseUrl": "https://raw.githubusercontent.com/mj1856/GeoTimeZone/master/LICENSE",
+        "repository": {
+            "type": "git",
+            "url": "https://github.com/mj1856/GeoTimeZone"
+        },
+        "requireLicenseAcceptance": false
+    }
+}


### PR DESCRIPTION
This is an alternative to a previous pull request by someone else to create a .NET Core compatible package. To me, it seems a preferable alternative.

Pro:
- changes to the original project are mostly zero, with the exception of adding on compile #if NET40.
- creating a nuget package is now mostly just 'dotnet pack'.

Con:
- I might didn't got it right.
- .nuspec -file has two entries that don't belong in there. I'm unsure which ones, doesn't actually matter, command dotnet ignores it anyway, and just does what it does.
- .xproj -files are now officially deprecated, so let's see what happens in the future. This might be a very temporary solution.
